### PR TITLE
Replace Guzzle with Symfony HTTP Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "sylius/calendar": "0.*",
         "sylius/mailer-bundle": "^1.8 || ^2.0",
         "sylius/sylius": "~1.10.0 || ~1.11.0 || ~1.12.0",
+        "symfony/http-client": "5.4.* || ^6.0",
         "symfony/messenger": "5.4.* || ^6.0",
         "symfony/uid": "5.4.* || ^6.0",
         "symfony/webpack-encore-bundle": "^1.15"

--- a/config/services/clients.php
+++ b/config/services/clients.php
@@ -19,7 +19,7 @@ return static function (ContainerConfigurator $containerConfigurator) {
         ->set(SaferpayClientInterface::class, SaferpayClient::class)
         ->public()
         ->args([
-            service('sylius.http_client'),
+            service('http_client'),
             service(SaferpayClientBodyFactoryInterface::class),
             service(SaferpayApiBaseUrlResolverInterface::class),
             service(PaymentEventDispatcherInterface::class),


### PR DESCRIPTION
In Symfony HTTP Client, non-success codes are not converted to exceptions, so I removed all throw-related specs. We might consider handling other kinds of HTTP errors handling, but it's out of the scope of this task, as they weren't handled previously.