### PR TITLE
Remove unnecessary step from contract tests

### DIFF
--- a/tests/Application/package.json
+++ b/tests/Application/package.json
@@ -8,6 +8,6 @@
     "watch": "encore dev --watch"
   },
   "devDependencies": {
-    "@sylius-ui/frontend": "^1.0"
+    "@sylius-ui/frontend": "1.0.1"
   }
 }

--- a/tests/Contract/PaymentPage/AssertTest.php
+++ b/tests/Contract/PaymentPage/AssertTest.php
@@ -16,7 +16,6 @@ final class AssertTest extends SaferpayApiTestCase
         $initializeData = $this->iInitializePayment();
 
         $this->iOpen($initializeData->getRedirectUrl());
-        $this->iChooseVisaCardAsPaymentMethod();
         $this->iConfirmCardData();
         $this->iChoosePaymentInDollars();
         $this->iProcessSuccessfully3dSecureAuthentication();

--- a/tests/Contract/SaferpayHelperTrait.php
+++ b/tests/Contract/SaferpayHelperTrait.php
@@ -24,11 +24,6 @@ trait SaferpayHelperTrait
         self::$pantherClient->get($url);
     }
 
-    protected function iChooseVisaCardAsPaymentMethod(): void
-    {
-        self::$pantherClient->getWebDriver()->findElement(WebDriverBy::className('btn-card-visa'))->click();
-    }
-
     protected function iConfirmCardData(): void
     {
         self::$pantherClient->waitFor('.btn-next');
@@ -55,7 +50,6 @@ trait SaferpayHelperTrait
         $initializeData = $this->iInitializePayment();
 
         $this->iOpen($initializeData->getRedirectUrl());
-        $this->iChooseVisaCardAsPaymentMethod();
         $this->iConfirmCardData();
         $this->iChoosePaymentInDollars();
         $this->iProcessSuccessfully3dSecureAuthentication();


### PR DESCRIPTION
As the UI of Saferpay has been changed, the step for choosing the credit card is not needed